### PR TITLE
fix: Friendship Cache Issue

### DIFF
--- a/src/middlewares/cache.middleware.ts
+++ b/src/middlewares/cache.middleware.ts
@@ -24,6 +24,11 @@ export function cacheMiddleware({
         ? (req as AuthenticatedUserRequestInterface)?.userId
         : null;
 
+      //todo: Make changes to the cache key
+      //it works for routes like /a/:id but not for /a/b
+      //this results into rewriting the cache for /friendship/list and /friendship/requests
+      //req.baseUrl only returns /a, Example: /friendship not /friendship/list
+
       const cachedData = await getAPICache({
         url: req.baseUrl,
         params: req.params,

--- a/src/routes/v1/friendship.routes.ts
+++ b/src/routes/v1/friendship.routes.ts
@@ -26,14 +26,14 @@ friendshipRouter.patch(
 friendshipRouter.get(
   "/list",
   validate(friendshipValidationSchemas.getFriendsListValidatorSchema),
-  cacheMiddleware({ isAuthenticatedUserSpecificRequest: true }),
+  // cacheMiddleware({ isAuthenticatedUserSpecificRequest: true }),
   friendshipController.getFriendsList
 );
 
 friendshipRouter.get(
   "/requests",
   validate(friendshipValidationSchemas.getPendingFriendRequestsValidatorSchema),
-  cacheMiddleware({ isAuthenticatedUserSpecificRequest: true }),
+  // cacheMiddleware({ isAuthenticatedUserSpecificRequest: true }),
   friendshipController.getPendingFriendRequests
 );
 


### PR DESCRIPTION
This pull request includes changes to the caching mechanism and the routing for friendship-related endpoints. The most important changes involve adding comments for future improvements to the cache key generation and temporarily disabling the cache middleware for specific routes.

Caching mechanism improvements:

* [`src/middlewares/cache.middleware.ts`](diffhunk://#diff-8fc99348086e51a08e4ed31efa220239bd0cae22d54cefd553115ba5394c1726R27-R31): Added comments to indicate the need for changes to the cache key generation to handle routes like `/a/b` correctly.

Routing adjustments:

* [`src/routes/v1/friendship.routes.ts`](diffhunk://#diff-00a73832a28212f26b53fd748f8de78280b25f3b8c41f4d3f190d6fbec8daa71L29-R36): Temporarily disabled the `cacheMiddleware` for the `/list` and `/requests` routes by commenting out the middleware function.